### PR TITLE
Update github workflow to use smithy cli

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -9,19 +9,16 @@ on:
 jobs:
   build:
     runs-on: macos-latest
-    name: Java ${{ matrix.java }}
-    strategy:
-      matrix:
-        java: [8, 11, 17]
+    name: Java 17 MacOs
 
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
 
-      - name: Set up JDK ${{ matrix.java }}
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 17
           distribution: 'zulu'
 
       - name: Install smithy cli


### PR DESCRIPTION
Description of changes:
Updates the github actions to use only macos and to use brew to install the smithy CLI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
