### PR TITLE
Remove all references to Apache-2.0 and change to MIT-0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 
 ## License
 
-This project is licensed under the Apache-2.0 License.
+This project is licensed under the MIT-0 License.
 

--- a/custom-traits/config/checkstyle/checkstyle.xml
+++ b/custom-traits/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
   ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  ~ SPDX-License-Identifier: Apache-2.0
+  ~ SPDX-License-Identifier: MIT-0
   -->
 <!DOCTYPE module PUBLIC
         "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"

--- a/custom-traits/custom-annotation-trait/config/checkstyle/checkstyle.xml
+++ b/custom-traits/custom-annotation-trait/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
   ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  ~ SPDX-License-Identifier: Apache-2.0
+  ~ SPDX-License-Identifier: MIT-0
   -->
 <!DOCTYPE module PUBLIC
         "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
@@ -21,7 +21,7 @@
     <!-- Files must contain a copyright header, with or without a year. -->
     <module name="RegexpHeader">
         <property name="header"
-                  value="/\*\n \* Copyright( 20(19|20|21|22|23)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
+                  value="/\*\n \* Copyright( 20(19|20|21|22|23|24|25)|) "/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/custom-traits/custom-annotation-trait/config/checkstyle/suppressions.xml
+++ b/custom-traits/custom-annotation-trait/config/checkstyle/suppressions.xml
@@ -1,17 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License").
-  ~ You may not use this file except in compliance with the License.
-  ~ A copy of the License is located at
-  ~
-  ~  http://aws.amazon.com/apache2.0
-  ~
-  ~ or in the "license" file accompanying this file. This file is distributed
-  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-  ~ express or implied. See the License for the specific language governing
-  ~ permissions and limitations under the License.
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
   -->
 <!DOCTYPE suppressions PUBLIC
         "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"

--- a/custom-traits/custom-annotation-trait/config/spotbugs/filter.xml
+++ b/custom-traits/custom-annotation-trait/config/spotbugs/filter.xml
@@ -1,19 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License").
-  ~ You may not use this file except in compliance with the License.
-  ~ A copy of the License is located at
-  ~
-  ~  http://aws.amazon.com/apache2.0
-  ~
-  ~ or in the "license" file accompanying this file. This file is distributed
-  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-  ~ express or implied. See the License for the specific language governing
-  ~ permissions and limitations under the License.
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
   -->
-
 <FindBugsFilter>
     <!-- Ignore all test files. -->
     <Match>

--- a/custom-traits/custom-annotation-trait/src/main/java/io/smithy/examples/traits/SpecialTrait.java
+++ b/custom-traits/custom-annotation-trait/src/main/java/io/smithy/examples/traits/SpecialTrait.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: MIT-0
  */
 
 package io.smithy.examples.traits;

--- a/custom-traits/custom-string-trait/config/checkstyle/checkstyle.xml
+++ b/custom-traits/custom-string-trait/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
   ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  ~ SPDX-License-Identifier: Apache-2.0
+  ~ SPDX-License-Identifier: MIT-0
   -->
 <!DOCTYPE module PUBLIC
         "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
@@ -21,7 +21,7 @@
     <!-- Files must contain a copyright header, with or without a year. -->
     <module name="RegexpHeader">
         <property name="header"
-                  value="/\*\n \* Copyright( 20(19|20|21|22|23)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
+                  value="/\*\n \* Copyright( 20(19|20|21|22|23|24|25)|) "/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/custom-traits/custom-string-trait/config/checkstyle/suppressions.xml
+++ b/custom-traits/custom-string-trait/config/checkstyle/suppressions.xml
@@ -1,17 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License").
-  ~ You may not use this file except in compliance with the License.
-  ~ A copy of the License is located at
-  ~
-  ~  http://aws.amazon.com/apache2.0
-  ~
-  ~ or in the "license" file accompanying this file. This file is distributed
-  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-  ~ express or implied. See the License for the specific language governing
-  ~ permissions and limitations under the License.
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
   -->
 <!DOCTYPE suppressions PUBLIC
         "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"

--- a/custom-traits/custom-string-trait/config/spotbugs/filter.xml
+++ b/custom-traits/custom-string-trait/config/spotbugs/filter.xml
@@ -1,19 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License").
-  ~ You may not use this file except in compliance with the License.
-  ~ A copy of the License is located at
-  ~
-  ~  http://aws.amazon.com/apache2.0
-  ~
-  ~ or in the "license" file accompanying this file. This file is distributed
-  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-  ~ express or implied. See the License for the specific language governing
-  ~ permissions and limitations under the License.
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
   -->
-
 <FindBugsFilter>
     <!-- Ignore all test files. -->
     <Match>

--- a/custom-traits/custom-string-trait/src/main/java/io/smithy/examples/traits/JsonNameTrait.java
+++ b/custom-traits/custom-string-trait/src/main/java/io/smithy/examples/traits/JsonNameTrait.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: MIT-0
  */
 
 package io.smithy.examples.traits;

--- a/custom-traits/custom-string-trait/src/main/java/io/smithy/examples/validators/JsonNameTraitValidator.java
+++ b/custom-traits/custom-string-trait/src/main/java/io/smithy/examples/validators/JsonNameTraitValidator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: MIT-0
  */
 
 package io.smithy.examples.validators;

--- a/custom-traits/custom-structure-trait/config/checkstyle/checkstyle.xml
+++ b/custom-traits/custom-structure-trait/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
   ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  ~ SPDX-License-Identifier: Apache-2.0
+  ~ SPDX-License-Identifier: MIT-0
   -->
 <!DOCTYPE module PUBLIC
         "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
@@ -21,7 +21,7 @@
     <!-- Files must contain a copyright header, with or without a year. -->
     <module name="RegexpHeader">
         <property name="header"
-                  value="/\*\n \* Copyright( 20(19|20|21|22|23)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
+                  value="/\*\n \* Copyright( 20(19|20|21|22|23|24|25)|) "/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/custom-traits/custom-structure-trait/config/checkstyle/suppressions.xml
+++ b/custom-traits/custom-structure-trait/config/checkstyle/suppressions.xml
@@ -1,17 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License").
-  ~ You may not use this file except in compliance with the License.
-  ~ A copy of the License is located at
-  ~
-  ~  http://aws.amazon.com/apache2.0
-  ~
-  ~ or in the "license" file accompanying this file. This file is distributed
-  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-  ~ express or implied. See the License for the specific language governing
-  ~ permissions and limitations under the License.
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
   -->
 <!DOCTYPE suppressions PUBLIC
         "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"

--- a/custom-traits/custom-structure-trait/config/spotbugs/filter.xml
+++ b/custom-traits/custom-structure-trait/config/spotbugs/filter.xml
@@ -1,19 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License").
-  ~ You may not use this file except in compliance with the License.
-  ~ A copy of the License is located at
-  ~
-  ~  http://aws.amazon.com/apache2.0
-  ~
-  ~ or in the "license" file accompanying this file. This file is distributed
-  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-  ~ express or implied. See the License for the specific language governing
-  ~ permissions and limitations under the License.
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
   -->
-
 <FindBugsFilter>
     <!-- Ignore all test files. -->
     <Match>

--- a/custom-traits/custom-structure-trait/src/main/java/io/smithy/examples/traits/ResourceMetadataTrait.java
+++ b/custom-traits/custom-structure-trait/src/main/java/io/smithy/examples/traits/ResourceMetadataTrait.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: MIT-0
  */
 
 package io.smithy.examples.traits;

--- a/custom-traits/custom-structure-trait/src/main/java/io/smithy/examples/validators/ResourceMetadataTraitValidator.java
+++ b/custom-traits/custom-structure-trait/src/main/java/io/smithy/examples/validators/ResourceMetadataTraitValidator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: MIT-0
  */
 
 package io.smithy.examples.validators;


### PR DESCRIPTION
Description of changes:
Removes any references to Apache-2.0 that were missed on the first pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
