### PR TITLE
Add workflow to scan for git secrets

### DIFF
--- a/.github/workflows/git-secrets.yml
+++ b/.github/workflows/git-secrets.yml
@@ -1,0 +1,24 @@
+name: git-secrets
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  git-secrets:
+    runs-on: macos-latest
+    name: Git Secrets
+
+    steps:
+      - name: Check Out Source Code
+        uses: actions/checkout@v2
+      - name: Installing scanning tool
+        run: |
+          brew install git-secrets
+          git secrets --install
+          git secrets --register-aws
+      - name: Running scanning tool
+        run:
+          git secrets --scan


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Adds a workflow to run [git-secrets](https://github.com/awslabs/git-secrets) check on the repository to ensure no AWS secrets are committed

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
