### PR TITLE
Add linting and validation examples to templates file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ API documentation, test automation, and example code.
 - [Projections](projection-examples/README.md) - Using Smithy [projections](https://smithy.io/2.0/guides/building-models/build-config.html#projections) to create different views of 
   your model for specific consumers.
 - [Shared Models](shared-models/README.md) - Create a package of common Smithy shapes that can be shared between Smithy models.
-
+- [Linting and Validation](linting-and-validation-examples/README.md) - Use linters and validators to ensure APIs adhere to best practices and standards.
 
 ## Contributing
 Contributions are welcome. Please read the [contribution guidelines](CONTRIBUTING.md) first.

--- a/smithy-templates.json
+++ b/smithy-templates.json
@@ -65,6 +65,42 @@
         "gradle.properties",
         ".gitignore"
       ]
+    },
+    "common-linting-configuration": {
+      "documentation": "Gradle project to create a package to define a common set of model validations.",
+      "path": "linting-and-validation-examples/common-linting-configuration",
+      "include": [
+        "config/",
+        "gradle/",
+        "gradlew",
+        "gradlew.bat",
+        "gradle.properties",
+        ".gitignore"
+      ]
+    },
+    "custom-linter": {
+      "documentation": "Gradle project to create a custom, configurable model linter.",
+      "path": "linting-and-validation-examples/custom-linter",
+      "include": [
+        "config/",
+        "gradle/",
+        "gradlew",
+        "gradlew.bat",
+        "gradle.properties",
+        ".gitignore"
+      ]
+    },
+    "custom-validator": {
+      "documentation": "Gradle project to create a custom model validator.",
+      "path": "linting-and-validation-examples/custom-validator",
+      "include": [
+        "config/",
+        "gradle/",
+        "gradlew",
+        "gradlew.bat",
+        "gradle.properties",
+        ".gitignore"
+      ]
     }
   }
 }


### PR DESCRIPTION
*Description of changes*:
Adds model linting and validation examples to the templates.json file.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
