### PR TITLE
update workflow to use PR token

### DIFF
--- a/.github/workflows/update-smithy-version.yml
+++ b/.github/workflows/update-smithy-version.yml
@@ -60,4 +60,4 @@ jobs:
             --base main
           echo "PR Created for version bump to ${{ steps.fetch-latest.outputs.latestSmithy }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PR_TOKEN }}


### PR DESCRIPTION
*Description of changes*:
Updates the update workflow to use a PR token instead of the GITHUB_TOKEN so that the integ workflow will be run on the created PRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
