### PR TITLE
add brew update step to integ workflow

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -22,7 +22,12 @@ jobs:
           distribution: 'zulu'
 
       - name: Install smithy cli
-        run: brew tap aws/tap && brew install smithy-cli
+        run: |
+          brew tap aws/tap
+          brew update
+          brew install smithy-cli
+          brew upgrade smithy-cli
+          echo "Smithy CLI version $(smithy --version) installed"
 
       - name: Execute integration tests
         run: make test-all


### PR DESCRIPTION
*Description of changes*:
Previous workflow runs were not catching the update to the smithy cli formula. This change adds an explicit step to update brew and upgrade the smithy cli


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
