### PR TITLE
make smithy update workflow run on a weekly basis

### DIFF
--- a/.github/workflows/update-smithy-version.yml
+++ b/.github/workflows/update-smithy-version.yml
@@ -1,10 +1,9 @@
 name: Get latest smithy release version
 on:
   workflow_dispatch: # on button click
-  # Uncomment once permissions to create PRs has been added.
-  #schedule:
+  schedule:
     # Runs every wednesday at 10
-    #- cron:  '0 10 * * WED'
+    - cron:  '0 10 * * WED'
 
 jobs:
   get-version:


### PR DESCRIPTION
*Description of changes*:
Changes the smithy version update workflow to run once a week now we have tested it manually.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
