### PR TITLE
Add .gitattributes fileand include in gradle templates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+#
+# https://help.github.com/articles/dealing-with-line-endings/
+#
+# Linux start script should use lf
+/gradlew        text eol=lf
+
+# These are Windows script files and should use crlf
+*.bat           text eol=crlf

--- a/smithy-templates.json
+++ b/smithy-templates.json
@@ -8,7 +8,7 @@
     "quickstart-gradle": {
       "documentation": "Smithy Quickstart example weather service using the Smithy-Gradle-Plugin.",
       "path": "getting-started-examples/getting-started-gradle",
-      "include": [ ".gitignore" ]
+      "include": [ ".gitignore", ".gitattributes" ]
     },
     "custom-annotation-trait": {
       "documentation": "Gradle project for creating a package for a custom annotation trait.",
@@ -19,7 +19,8 @@
         "gradlew",
         "gradlew.bat",
         "gradle.properties",
-        ".gitignore"
+        ".gitignore",
+        ".gitattributes"
       ]
     },
     "custom-string-trait": {
@@ -31,7 +32,8 @@
         "gradlew",
         "gradlew.bat",
         "gradle.properties",
-        ".gitignore"
+        ".gitignore",
+        ".gitattributes"
       ]
     },
     "custom-structure-trait": {
@@ -43,7 +45,8 @@
         "gradlew",
         "gradlew.bat",
         "gradle.properties",
-        ".gitignore"
+        ".gitignore",
+        ".gitattributes"
       ]
     },
     "filter-internal-projection": {
@@ -63,7 +66,8 @@
         "gradlew",
         "gradlew.bat",
         "gradle.properties",
-        ".gitignore"
+        ".gitignore",
+        ".gitattributes"
       ]
     },
     "common-linting-configuration": {
@@ -75,7 +79,8 @@
         "gradlew",
         "gradlew.bat",
         "gradle.properties",
-        ".gitignore"
+        ".gitignore",
+        ".gitattributes"
       ]
     },
     "custom-linter": {
@@ -87,7 +92,8 @@
         "gradlew",
         "gradlew.bat",
         "gradle.properties",
-        ".gitignore"
+        ".gitignore",
+        ".gitattributes"
       ]
     },
     "custom-validator": {
@@ -99,7 +105,8 @@
         "gradlew",
         "gradlew.bat",
         "gradle.properties",
-        ".gitignore"
+        ".gitignore",
+        ".gitattributes"
       ]
     },
     "decorators": {
@@ -111,7 +118,8 @@
         "gradlew",
         "gradlew.bat",
         "gradle.properties",
-        ".gitignore"
+        ".gitignore",
+        ".gitattributes"
       ]
     }
   }


### PR DESCRIPTION
*Issue # (if available)*:

*Description of changes*:
Adds `.gitattributes` file to gradle templates. This ensures the templates match what a user would get with building the example from scratch using `gradle init`.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
