### PR TITLE
Fix the tests cases to account for events that were swallowed

### DIFF
--- a/linting-and-validation-examples/integ/decorators-test/src/test/java/io/smithy/examples/decorators/DecoratorsTest.java
+++ b/linting-and-validation-examples/integ/decorators-test/src/test/java/io/smithy/examples/decorators/DecoratorsTest.java
@@ -17,9 +17,9 @@ public class DecoratorsTest {
                         .addImport(getClass().getResource("unknown-aws-protocol.smithy"))
                         .assemble();
         assertTrue(result.isBroken());
-        assertEquals(result.getValidationEvents().size(), 1);
-        assertTrue(result.getValidationEvents().get(0).getHint().isPresent());
-        assertTrue(result.getValidationEvents().get(0).getHint().get().contains("smithy-aws-traits"));
+        assertEquals(result.getValidationEvents().size(), 2);
+        assertTrue(result.getValidationEvents().get(1).getHint().isPresent());
+        assertTrue(result.getValidationEvents().get(1).getHint().get().contains("smithy-aws-traits"));
     }
 
     @Test
@@ -29,8 +29,8 @@ public class DecoratorsTest {
                         .addImport(getClass().getResource("unknown-validation-exception-shape.smithy"))
                         .assemble();
         assertTrue(result.isBroken());
-        assertEquals(result.getValidationEvents().size(), 1);
-        assertTrue(result.getValidationEvents().get(0).getHint().isPresent());
-        assertTrue(result.getValidationEvents().get(0).getHint().get().contains("smithy-validation-model"));
+        assertEquals(result.getValidationEvents().size(), 2);
+        assertTrue(result.getValidationEvents().get(1).getHint().isPresent());
+        assertTrue(result.getValidationEvents().get(1).getHint().get().contains("smithy-validation-model"));
     }
 }


### PR DESCRIPTION
A change in Smithy fixed a bug that were swallowing some events. This change is to fix the tests that were broken due to that test.


Before (1.35.0)

```
 ✗ smithy validate ./src/test/resources/io/smithy/examples/decorators/unknown-aws-protocol.smithy

──  ERROR  ─────────────────────────────────────────────── Model.UnresolvedTrait
Shape: smithy.example#Weather
File:  ./src/test/resources/io/smithy/examples/decorators/unknown-aws-protocol.smithy:10:1

10| @restJson1
  | ^
11| service Weather {

Unable to resolve trait aws.protocols#restJson1. If this is a custom trait,
then it must be defined before it can be used in a model.

FAILURE: Validated 215 shapes (ERROR: 1)
```

And now:

```
✗ ~/Sources/smithy/smithy-cli/build/image/smithy-cli-darwin-aarch64/bin/smithy validate ./src/test/resources/io/smithy/examples/decorators/unknown-aws-protocol.smithy

──  WARNING  ───────────────────────────────────────────────────────────── Model
File:  ./src/test/resources/io/smithy/examples/decorators/unknown-aws-protocol.smithy:8:5

5| // aws.protocols#restJson1 is defined in the `smithy-aws-traits`
6| // package which is not in the classpath. An error with a hint
7| // pointing to this package should be emitted.
8| use aws.protocols#restJson1
 |     ^

Use statement refers to undefined shape: aws.protocols#restJson1


──  ERROR  ─────────────────────────────────────────────── Model.UnresolvedTrait
Shape: smithy.example#Weather
File:  ./src/test/resources/io/smithy/examples/decorators/unknown-aws-protocol.smithy:10:1

10| @restJson1
  | ^
11| service Weather {

Unable to resolve trait aws.protocols#restJson1. If this is a custom trait,
then it must be defined before it can be used in a model.

FAILURE: Validated 215 shapes (ERROR: 1, WARNING: 1)
```