### PR TITLE
Upgrade Gradle and Spotbugs versions

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -67,7 +67,6 @@
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -67,6 +67,7 @@
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
         <module name="JavadocMethod">
+            <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>

--- a/custom-trait-examples/custom-string-trait/build.gradle.kts
+++ b/custom-trait-examples/custom-string-trait/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     val smithyGradleVersion: String by project
 
     `java-library`
-    id("com.github.spotbugs").version("4.7.1")
+    id("com.github.spotbugs").version("4.7.3")
     id("software.amazon.smithy").version(smithyGradleVersion)
 }
 

--- a/custom-trait-examples/custom-structure-trait/build.gradle.kts
+++ b/custom-trait-examples/custom-structure-trait/build.gradle.kts
@@ -4,7 +4,7 @@ description = "Custom Smithy structure trait with multiple inputs"
 plugins {
     val smithyGradleVersion: String by project
     `java-library`
-    id("com.github.spotbugs").version("4.7.1")
+    id("com.github.spotbugs").version("4.7.3")
     id("software.amazon.smithy").version(smithyGradleVersion)
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/linting-and-validation-examples/custom-linter/build.gradle.kts
+++ b/linting-and-validation-examples/custom-linter/build.gradle.kts
@@ -3,7 +3,7 @@ description = "A custom Smithy model-linter"
 
 plugins {
     `java-library`
-    id("com.github.spotbugs").version("4.7.1")
+    id("com.github.spotbugs").version("4.7.3")
 }
 
 java {

--- a/linting-and-validation-examples/custom-validator/build.gradle.kts
+++ b/linting-and-validation-examples/custom-validator/build.gradle.kts
@@ -4,7 +4,7 @@ description = "Creates a custom Smithy model validator"
 plugins {
     val smithyGradleVersion: String by project
     `java-library`
-    id("com.github.spotbugs").version("4.7.1")
+    id("com.github.spotbugs").version("4.7.3")
     id("software.amazon.smithy").version(smithyGradleVersion)
 }
 


### PR DESCRIPTION
### Description of changes
Upgrades the Gradle version to `8.2.1` in advance of updating examples to use the `0.8.0` version of the smithy-gradle-plugin.

Also upgrades the version of spotbugs plugin used.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
