### PR TITLE
Update gradle plugin upgrade workflow

### DIFF
--- a/.github/workflows/update-smithy-gradle-plugin-version.yml
+++ b/.github/workflows/update-smithy-gradle-plugin-version.yml
@@ -39,12 +39,19 @@ jobs:
           git config --global user.email "github-aws-smithy-automation@amazon.com"
           git config --global user.name "Smithy Automation"
 
-      - name: Find and replace
-        id: replace-current-version
+      - name: Find and replace gradle version in properties files
+        id: replace-current-version-properties
         if: steps.update-check.outputs.update-required == 'true'
         run: |
           find . -type f -name 'gradle.properties' \
           -exec sed -i "s|smithyGradleVersion=${{ steps.get-current.outputs.smithyGradleVersion }}|smithyGradleVersion=${{ steps.fetch-latest.outputs.latestSmithyGradle }}|g" {} \;
+
+      - name: Find and replace gradle plugin versions in build files
+        id: sync-plugin-version
+        if: steps.update-check.outputs.update-required == 'true'
+        run: |
+          find . -type f -name 'build.gradle.kts' \
+          -exec sed -i '' "s/\(id(\"software\.amazon\.smithy\.gradle\.smithy-\([[:lower:]]*\)\")\.version(\"\)\([[:digit:]\.]*\)\")/\\1${{ steps.fetch-latest.outputs.latestSmithyGradle }}\")/" {} \;
 
       - name: Create PR
         if: steps.update-check.outputs.update-required == 'true'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 smithyVersion=1.37.0
-smithyGradleVersion=0.7.0
+smithyGradleVersion=0.8.0


### PR DESCRIPTION
### Description of changes
Due to an issue with gradle 8.0 the gradle plugin versions need to be explicitly defined in build files rather than just in the gradle properties files. This pull request updates the gradle plugin workflow to update the plugin versions within gradle build files in addition to in gradle properties files.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
