### PR TITLE
Use gradle.properties for gradle plugin version

### DIFF
--- a/.github/workflows/update-smithy-version.yml
+++ b/.github/workflows/update-smithy-version.yml
@@ -15,7 +15,7 @@ jobs:
         id: fetch-latest
         run: |
           echo "latestSmithy=$( \
-            curl -sL https://api.github.com/repos/awslabs/smithy/releases/latest | \
+            curl -sL https://api.github.com/repos/smithy-lang/smithy/releases/latest | \
             jq -r '.tag_name')" >> $GITHUB_OUTPUT
 
       - name: Get current versions

--- a/custom-trait-examples/custom-annotation-trait/build.gradle.kts
+++ b/custom-trait-examples/custom-annotation-trait/build.gradle.kts
@@ -3,7 +3,7 @@ description = "A package used to define an annotation trait"
 plugins {
     `java-library`
     id("com.github.spotbugs").version("4.7.1")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 java {

--- a/custom-trait-examples/custom-annotation-trait/settings.gradle.kts
+++ b/custom-trait-examples/custom-annotation-trait/settings.gradle.kts
@@ -10,6 +10,11 @@
 rootProject.name = "custom-annotation-trait"
 
 pluginManagement {
+    val smithyGradleVersion: String by settings
+    plugins {
+        id("software.amazon.smithy.gradle.smithy-jar").version(smithyGradleVersion)
+    }
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/custom-trait-examples/custom-string-trait/build.gradle.kts
+++ b/custom-trait-examples/custom-string-trait/build.gradle.kts
@@ -4,7 +4,7 @@ description = "Package for a custom Smithy string trait"
 plugins {
     `java-library`
     id("com.github.spotbugs").version("4.7.3")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 java {

--- a/custom-trait-examples/custom-string-trait/settings.gradle.kts
+++ b/custom-trait-examples/custom-string-trait/settings.gradle.kts
@@ -10,6 +10,11 @@
 rootProject.name = "custom-string-trait"
 
 pluginManagement {
+    val smithyGradleVersion: String by settings
+    plugins {
+        id("software.amazon.smithy.gradle.smithy-jar").version(smithyGradleVersion)
+    }
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/custom-trait-examples/custom-structure-trait/build.gradle.kts
+++ b/custom-trait-examples/custom-structure-trait/build.gradle.kts
@@ -4,7 +4,7 @@ description = "Custom Smithy structure trait with multiple inputs"
 plugins {
     `java-library`
     id("com.github.spotbugs").version("4.7.3")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 java {

--- a/custom-trait-examples/custom-structure-trait/model/custom-trait.smithy
+++ b/custom-trait-examples/custom-structure-trait/model/custom-trait.smithy
@@ -5,7 +5,9 @@ namespace io.smithy.example
 @trait(
     selector: "resource"
     breakingChanges: [
-        {change: "presence"}
+        {
+            change: "presence"
+        }
     ]
 )
 structure resourceMetadata {

--- a/custom-trait-examples/custom-structure-trait/settings.gradle
+++ b/custom-trait-examples/custom-structure-trait/settings.gradle
@@ -1,5 +1,10 @@
 
 pluginManagement {
+    val smithyGradleVersion: String by settings
+    plugins {
+        id("software.amazon.smithy.gradle.smithy-jar").version(smithyGradleVersion)
+    }
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/custom-trait-examples/integ/custom-annotation-trait-test/build.gradle.kts
+++ b/custom-trait-examples/integ/custom-annotation-trait-test/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java-library")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 

--- a/custom-trait-examples/integ/custom-string-trait-test/build.gradle.kts
+++ b/custom-trait-examples/integ/custom-string-trait-test/build.gradle.kts
@@ -1,7 +1,7 @@
 
 plugins {
     id("java-library")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 

--- a/custom-trait-examples/integ/custom-structure-trait-test/build.gradle.kts
+++ b/custom-trait-examples/integ/custom-structure-trait-test/build.gradle.kts
@@ -1,7 +1,7 @@
 
 plugins {
     id("java-library")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 // The test project doesn't produce a JAR.

--- a/custom-trait-examples/integ/custom-structure-trait-test/model/main.smithy
+++ b/custom-trait-examples/integ/custom-structure-trait-test/model/main.smithy
@@ -10,7 +10,7 @@ use io.smithy.example#resourceMetadata
     associatedStructures: [ForecastStruct]
 )
 resource Forecast {
-    identifiers: {forecastId: ForecastId}
+    identifiers: { forecastId: ForecastId }
 }
 
 string ForecastId

--- a/linting-and-validation-examples/common-linting-configuration/build.gradle.kts
+++ b/linting-and-validation-examples/common-linting-configuration/build.gradle.kts
@@ -1,8 +1,8 @@
 description = "A package used to share a common linting configuration between smithy projects"
 
 plugins {
-    id("java-library")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    `java-library`
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 repositories {

--- a/linting-and-validation-examples/common-linting-configuration/model/validators.smithy
+++ b/linting-and-validation-examples/common-linting-configuration/model/validators.smithy
@@ -3,8 +3,14 @@ $version: "2.0"
 // The validators used here are either built-in linters (see: https://smithy.io/2.0/guides/model-linters.html#linters-in-smithy-linters)
 // or they are from the following guide:https://smithy.io/2.0/guides/model-validation-examples.html
 metadata validators = [
-    {name: "AbbreviationName", severity: "WARNING"}
-    {name: "CamelCase", severity: "WARNING"}
+    {
+        name: "AbbreviationName"
+        severity: "WARNING"
+    }
+    {
+        name: "CamelCase"
+        severity: "WARNING"
+    }
     {
         name: "MissingSensitiveTrait"
         severity: "WARNING"

--- a/linting-and-validation-examples/common-linting-configuration/settings.gradle.kts
+++ b/linting-and-validation-examples/common-linting-configuration/settings.gradle.kts
@@ -10,6 +10,11 @@
 rootProject.name = "common-linting-configuration"
 
 pluginManagement {
+    val smithyGradleVersion: String by settings
+    plugins {
+        id("software.amazon.smithy.gradle.smithy-jar").version(smithyGradleVersion)
+    }
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/linting-and-validation-examples/custom-validator/build.gradle.kts
+++ b/linting-and-validation-examples/custom-validator/build.gradle.kts
@@ -4,7 +4,7 @@ description = "Creates a custom Smithy model validator"
 plugins {
     `java-library`
     id("com.github.spotbugs").version("4.7.3")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 java {

--- a/linting-and-validation-examples/custom-validator/settings.gradle.kts
+++ b/linting-and-validation-examples/custom-validator/settings.gradle.kts
@@ -2,6 +2,11 @@
 rootProject.name = "custom-validator"
 
 pluginManagement {
+    val smithyGradleVersion: String by settings
+    plugins {
+        id("software.amazon.smithy.gradle.smithy-jar").version(smithyGradleVersion)
+    }
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/linting-and-validation-examples/integ/common-linting-configuration-test/build.gradle.kts
+++ b/linting-and-validation-examples/integ/common-linting-configuration-test/build.gradle.kts
@@ -1,7 +1,7 @@
 
 plugins {
     id("java-library")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 // The test project doesn't produce a JAR.

--- a/linting-and-validation-examples/integ/custom-linter-test/build.gradle.kts
+++ b/linting-and-validation-examples/integ/custom-linter-test/build.gradle.kts
@@ -1,7 +1,7 @@
 
 plugins {
     id("java-library")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 

--- a/linting-and-validation-examples/integ/custom-validator-test/build.gradle.kts
+++ b/linting-and-validation-examples/integ/custom-validator-test/build.gradle.kts
@@ -1,7 +1,7 @@
 
 plugins {
     id("java-library")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 

--- a/quickstart-examples/quickstart-gradle/build.gradle.kts
+++ b/quickstart-examples/quickstart-gradle/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java-library")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 repositories {

--- a/quickstart-examples/quickstart-gradle/gradle.properties
+++ b/quickstart-examples/quickstart-gradle/gradle.properties
@@ -1,1 +1,2 @@
 smithyVersion=1.44.0
+smithyGradleVersion=0.9.0

--- a/quickstart-examples/quickstart-gradle/settings.gradle.kts
+++ b/quickstart-examples/quickstart-gradle/settings.gradle.kts
@@ -1,5 +1,10 @@
 
 pluginManagement {
+    val smithyGradleVersion: String by settings
+    plugins {
+        id("software.amazon.smithy.gradle.smithy-jar").version(smithyGradleVersion)
+    }
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,11 @@
 
 pluginManagement {
+    val smithyGradleVersion: String by settings
+    plugins {
+        id("software.amazon.smithy.gradle.smithy-jar").version(smithyGradleVersion)
+        id("software.amazon.smithy.gradle.smithy-base").version(smithyGradleVersion)
+    }
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/shared-model-examples/common-shapes/build.gradle.kts
+++ b/shared-model-examples/common-shapes/build.gradle.kts
@@ -3,7 +3,7 @@ description = "A package used to share common shapes between smithy projects"
 
 plugins {
     `java-library`
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 repositories {

--- a/shared-model-examples/common-shapes/model/validators.smithy
+++ b/shared-model-examples/common-shapes/model/validators.smithy
@@ -1,11 +1,21 @@
 $version: "2.0"
 
 metadata validators = [
-    {name: "AbbreviationName"}
-    {name: "CamelCase"}
-    {name: "NoninclusiveTerms"}
-    {name: "RepeatedShapeName"}
-    {name: "ShouldHaveUsedTimestamp"}
+    {
+        name: "AbbreviationName"
+    }
+    {
+        name: "CamelCase"
+    }
+    {
+        name: "NoninclusiveTerms"
+    }
+    {
+        name: "RepeatedShapeName"
+    }
+    {
+        name: "ShouldHaveUsedTimestamp"
+    }
     // Require range for integers
     {
         name: "EmitEachSelector"

--- a/shared-model-examples/common-shapes/settings.gradle.kts
+++ b/shared-model-examples/common-shapes/settings.gradle.kts
@@ -2,6 +2,12 @@
 rootProject.name = "common-shapes"
 
 pluginManagement {
+    val smithyGradleVersion: String by settings
+
+    plugins {
+        id("software.amazon.smithy.gradle.smithy-jar").version(smithyGradleVersion)
+    }
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/shared-model-examples/integ/build.gradle.kts
+++ b/shared-model-examples/integ/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java-library")
-    id("software.amazon.smithy.gradle.smithy-jar").version("0.9.0")
+    id("software.amazon.smithy.gradle.smithy-jar")
 }
 
 // The test project doesn't produce a JAR.


### PR DESCRIPTION
### Description of changes
Updates the examples in the repository to use gradle properties to set the gradle plugin version. This will make it a bit easier to update the plugin version via github actions.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
