### PR TITLE
Update gradle workflow

### DIFF
--- a/.github/workflows/update-smithy-gradle-plugin-version.yml
+++ b/.github/workflows/update-smithy-gradle-plugin-version.yml
@@ -16,8 +16,8 @@ jobs:
         id: fetch-latest
         run: |
           echo "latestSmithyGradle=$( \
-            curl -sL https://plugins.gradle.org/m2/software/amazon/smithy/smithy-gradle-plugin/maven-metadata.xml | \
-            grep latest | cut -d'>' -f2 | cut -d'<' -f1)" >> $GITHUB_OUTPUT
+           curl -sL https://api.github.com/repos/smithy-lang/smithy-gradle-plugin/tags | \
+           jq -r '.[0].name')" >> $GITHUB_OUTPUT
 
       - name: Get current version
         id: get-current
@@ -46,18 +46,11 @@ jobs:
           find . -type f -name 'gradle.properties' \
           -exec sed -i "s|smithyGradleVersion=${{ steps.get-current.outputs.smithyGradleVersion }}|smithyGradleVersion=${{ steps.fetch-latest.outputs.latestSmithyGradle }}|g" {} \;
 
-      - name: Find and replace gradle plugin versions in build files
-        id: sync-plugin-version
-        if: steps.update-check.outputs.update-required == 'true'
-        run: |
-          find . -type f -name 'build.gradle.kts' \
-          -exec sed -i '' "s/\(id(\"software\.amazon\.smithy\.gradle\.smithy-\([[:lower:]]*\)\")\.version(\"\)\([[:digit:]\.]*\)\")/\\1${{ steps.fetch-latest.outputs.latestSmithyGradle }}\")/" {} \;
-
       - name: Create PR
         if: steps.update-check.outputs.update-required == 'true'
         run: |
           git add .
-          git commit -m 'Update smithy-gradle Version'
+          git commit -m 'Update smithy-gradle-plugin Version'
           git push --set-upstream origin "automation/bump-smithy-gradle-version/${{ steps.fetch-latest.outputs.latestSmithyGradle }}"
           gh pr create \
             --title "[Automation] smithy-gradle-plugin Version Bump - \`${{ steps.fetch-latest.outputs.latestSmithyGradle }}\`" \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 smithyVersion=1.44.0
-smithyGradleVersion=0.10.0
+smithyGradleVersion=0.9.0

--- a/quickstart-examples/quickstart-gradle/gradle.properties
+++ b/quickstart-examples/quickstart-gradle/gradle.properties
@@ -1,2 +1,2 @@
 smithyVersion=1.44.0
-smithyGradleVersion=0.10.0
+smithyGradleVersion=0.9.0


### PR DESCRIPTION
### Description of changes
Updates the gradle plugin auto-update workflow to use the tags from the smithy-gradle-plugin repo and only update the gradle.properties files with the updated version.

### Testing
This PR reverts the gradle plugin version to 0.9.0 so I can run the workflow and check that it works.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
