### PR TITLE
Use fully qualified coords

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -25,10 +25,9 @@ jobs:
         run: |
           brew tap smithy-lang/tap
           brew update
-          brew install smithy-cli
-          brew upgrade smithy-cli
+          brew install smithy-lang/tap/smithy-cli
+          brew upgrade smithy-lang/tap/smithy-cli
           echo "Smithy CLI version $(smithy --version) installed"
 
       - name: Execute integration tests
         run: make test-all
-        


### PR DESCRIPTION
#### Background
* Tries to fix failures occuring in Integ workflow by setting full coordinates for CLI 

#### Testing
* See integ test in this PR

#### Links
* old failures: https://github.com/smithy-lang/smithy-examples/actions/runs/8054592090/job/21999710494

---
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
