### PR TITLE
Correct Java quickstart main class.

### DIFF
--- a/smithy-java-examples/quickstart-java/client/build.gradle.kts
+++ b/smithy-java-examples/quickstart-java/client/build.gradle.kts
@@ -34,5 +34,5 @@ tasks.named("compileJava") {
 }
 
 application {
-    mainClass = "io.smithy.java.client.example.ClientEntrypoint"
+    mainClass = "io.smithy.java.client.example.Main"
 }


### PR DESCRIPTION
#### Background
Corrects the main class name used for the java quickstart client application.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
