### PR TITLE
Update the smithy-rs packages to 0.1.2 in the Rust quickstart.

### DIFF
--- a/smithy-rs-examples/quickstart-rust/gradle.properties
+++ b/smithy-rs-examples/quickstart-rust/gradle.properties
@@ -1,3 +1,3 @@
 smithyVersion=1.62.0
 smithyGradleVersion=1.3.0
-smithyRsVersion=0.1.0
+smithyRsVersion=0.1.2


### PR DESCRIPTION

#### Background
* What do these changes do? 

The current Rust quickstart fails to build with
```
❯ gradle build
> Task :client:smithyBuild FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':client:smithyBuild'.
> Could not resolve all files for configuration ':client:smithyBuild'.
   > Could not find org.jetbrains.kotlin:kotlin-stdlib-jdk8:unspecified.
```

Updating the Rust codegen maven dependencies from 0.1.0 appears to address the issue.

* Was a new example added? If so, what does it demonstrate? N/A

#### Testing
* How did you test these changes?

Confirmed that bumping the smithy Rust codegen dependency appears to have resolved the issue. I'm having trouble parsing, from the smithy-rs releases, what could have caused this issue. Versions 0.1.1 and 0.1.2 don't exhibit this problem.

* Was an integration test added for any new examples? N/A
* If a new example was added did you update the `smithy-templates.json` file? N/A

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
