### PR TITLE
Filter out BDD-based endpoints

### DIFF
--- a/smithy-typescript-examples/minimal-aws-sdk-client/smithy-build.json
+++ b/smithy-typescript-examples/minimal-aws-sdk-client/smithy-build.json
@@ -23,7 +23,7 @@
                 {
                     "name": "excludeTraits",
                     "args": {
-                        "traits": ["smithy.rules#endpointRuleSet", "smithy.rules#endpointTests"]
+                        "traits": ["smithy.rules#endpointRuleSet", "smithy.rules#endpointTests", "smithy.rules#endpointBdd"]
                     }
                 },
                 // Remove any shapes that are unused (such as the inputs and outputs of removed operations)


### PR DESCRIPTION
#### Background
Smithy `1.72.0` added validation that requires endpoint rule-set parameters to be bound to operations. The minimal SDK example triggers this validation because it removes most DynamoDB operations but was not filtering out the BDD-backed endpoint rule-set trait now present on the DynamoDB model: `smithy.rules#endpointBdd`.

Filter out `smithy.rules#endpointBdd` along with the existing endpoint rule-set traits.

#### Testing
Ran `make test-all` to run integration tests

---
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
